### PR TITLE
Added missing module.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ wandb
 torch
 dataclasses
 scikit-learn
+tree_sitter


### PR DESCRIPTION
Fix the following error:

```
$ python main.py --model codet5 --task assert --subset raw
Traceback (most recent call last):
  File "FineTuner/src/main.py", line 16, in <module>
    from run_fine_tune import run_fine_tune
  File "FineTuner/src/run_fine_tune.py", line 19, in <module>
    from evaluation.CodeBLEU.calc_code_bleu import code_bleu
  File "FineTuner/src/evaluation/CodeBLEU/calc_code_bleu.py", line 10, in <module>
    import evaluation.CodeBLEU.syntax_match as syntax_match
  File "FineTuner/src/evaluation/CodeBLEU/syntax_match.py", line 5, in <module>
    from tree_sitter import Language, Parser
ModuleNotFoundError: No module named 'tree_sitter'
```