### PR TITLE
Added missing plbart's dep.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torch
 dataclasses
 scikit-learn
 tree_sitter
+sentencepiece


### PR DESCRIPTION
This PR fixes the following error

```bash
$ python main.py --model plbart --task assert --subset raw --train_batch_size 16 --eval_batch_size 16
==================== INITIALIZING ====================
Distributed environment: NO
Num processes: 1
Process index: 0
Local process index: 0
Device: cuda
Mixed precision type: fp16
==================== LOADING ====================
Downloading (…)lve/main/config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 783/783 [00:00<00:00, 47.3kB/s]
Loaded config 'PLBartConfig' from 'uclanlp/plbart-base'
Traceback (most recent call last):
  File "/tmp/FineTuner/src/main.py", line 113, in <module>
    main()
  File "/tmp/FineTuner/src/main.py", line 109, in main
    run_fine_tune(args, accelerator, run)
  File "/tmp/FineTuner/src/run_fine_tune.py", line 270, in run_fine_tune
    model, tokenizer = build_model_tokenizer(args)
  File "/tmp/FineTuner/src/models.py", line 280, in build_model_tokenizer
    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name)
  File "/tmp/FineTuner/fine-tuner/lib/python3.9/site-packages/transformers/models/auto/tokenization_auto.py", line 681, in from_pretrained
    raise ValueError(
ValueError: This tokenizer cannot be instantiated. Please make sure you have `sentencepiece` installed in order to use this tokenizer.
```